### PR TITLE
wheels musllinux

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -136,11 +136,42 @@ jobs:
           name: wheels
           path: dist
 
+  build_wheels:
+    name: Build wheels for musllinux
+    runs-on: ubuntu-latest
+
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y"
+      CIBW_ARCHS_LINUX: "auto aarch64"
+      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
+      CIBW_BUILD: "*-musllinux_x86_64 *-musllinux_aarch64"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-*"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.9.0
+        with:
+          output-dir: dist
+
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [ macos, windows, linux]
+    needs: [ macos, windows, linux, build_wheels]
     steps:
       - uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
Hi. You have recently created wheels for aarch64 platform. Especially, for `manylinux`  systems. But I'm working with Home Assistant OS and it is `musllinux` system. So, all generated wheels are unsuitable for this system.

I really need this wheels,because otherwise my HA integrations doesn't work property. I've decided to create github action for it. Also, I've integrated this action in your github action for PyPi.Wheels already tested on RPi4 with HomeAssistant OS and everything is working. 

Please, add this wheels to Pypi. 
If any questions, fill free to ask.