### PR TITLE
Update pyo3 to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ extension-module = ["pyo3/extension-module"]
 default = ["extension-module"]
 
 [dependencies.pyo3]
-version = "0.10.1"
+version = "0.11.0"
 
 [package.metadata.maturin]
 maintainer = "Stichting Polkascan (Polkascan Foundation)"


### PR DESCRIPTION
This PR updates the https://github.com/PyO3/pyo3 dependency to version [0.11.0](https://github.com/PyO3/pyo3/releases/tag/v0.11.0) . That is the first version which supports the stable Rust toolchain. This upgrade is required to build this package for NixOS (as a dependency of `bip_utils`), see the discussion in https://github.com/NixOS/nixpkgs/pull/194954 .